### PR TITLE
NOJIRA: Display high contrast theme adjusters.

### DIFF
--- a/src/shared/adjusters/css/adjusters.css
+++ b/src/shared/adjusters/css/adjusters.css
@@ -53,6 +53,11 @@ textarea:focus, input:focus {
     margin-right: 10%;
     font-family: 'Open Sans', sans-serif;
 }
+#gpiic-pcp .gpii-prefsEditor-category {
+    width: 80%;
+    margin-left: 4%;
+    margin-right: 10%;
+}
 
 .gpii-prefsEditor label::first-letter,
 .gpii-prefsEditor h1::first-letter,
@@ -96,6 +101,9 @@ h2 > label {
 
 .gpii-prefsEditor-headerImage:before {
     font-size: 90px !important;
+}
+#gpiic-pcp .gpii-prefsEditor-headerImage:before {
+    font-size: 30px !important;
 }
 
 .gpii-prefsEditor-headerImageTick {
@@ -151,6 +159,10 @@ input[type=checkbox]:checked + .gpii-prefsEditor-headerImage > .gpii-prefsEditor
     border-left: 0px;
     padding-right: 230px;
 }
+#gpiic-pcp .gpii-prefsEditor-headerTitle-withoutIcon {
+    width: 190px; /* CS: first increased to 262px to compensate for the smaller icon, then reduced to compensate for other changes*/
+    height: 30px;
+}
 
 .gpii-prefsEditor-headerTitle {
     font-family: 'Roboto Slab', serif;
@@ -159,6 +171,9 @@ input[type=checkbox]:checked + .gpii-prefsEditor-headerImage > .gpii-prefsEditor
     color:#566374;
     float: none;
     vertical-align: middle;
+}
+#gpiic-pcp .gpii-prefsEditor-headerTitle {
+    font-size: 1.2em !important;
 }
 
 .gpii-prefsEditor-headerClickableLabel {
@@ -1114,6 +1129,11 @@ input:checked + label > span > span > .gpii-iconCheckAdjusterCheckIcon:before {
     cursor: pointer;
     text-align: left !important;
 }
+#gpiic-pcp .gpii-contrastThemeLabel {
+    font-size: 1.2em !important;
+    height: 1.3em !important;
+    width: 90% !important;
+}
 
 .gpii-contrastThemeLabel > span {
     display: table-cell;
@@ -1122,6 +1142,9 @@ input:checked + label > span > span > .gpii-iconCheckAdjusterCheckIcon:before {
 
 .fl-prefsEditor .fl-choice label {
     line-height: 1.5em !important;
+}
+#gpiic-pcp .fl-prefsEditor .fl-choice label {
+    line-height: 1em !important;
 }
 
 .fl-prefsEditor .fl-choice .fl-indicator {
@@ -1228,6 +1251,12 @@ h4 {
     transition-duration: 0.2s;
     transition-property: padding-left, width, background-color, margin-left;
     font-size: 1.1em;
+    font-weight: 700;
+}
+#gpiic-pcp .fl-prefsEditor .fl-prefsEditor-onoff .fl-prefsEditor-switch {
+    height: 2.1em;
+    box-shadow: 1em 1.1em 0 0 rgba(250,250,250,0.53) inset;
+    font-size: 1em;
     font-weight: 700;
 }
 
@@ -1503,6 +1532,9 @@ input[type=checkbox] + label.gpii-checkbox-label {
 .fl-prefsEditor label {
     text-transform: none;
     font-size: 1.2em;
+}
+#gpiic-pcp .fl-prefsEditor label {
+    font-size: 1em;
 }
 
 /*

--- a/src/shared/common/GpiiStore.js
+++ b/src/shared/common/GpiiStore.js
@@ -81,7 +81,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
         "http://registry\\.gpii\\.net/common/showCrosshairs": "gpii_primarySchema_showCrosshairs",
 
 
-        // application specific ters transforamtions
+        // application-specific term transformations
 
 
         // Windows

--- a/src/shared/frames/css/frames.css
+++ b/src/shared/frames/css/frames.css
@@ -21,6 +21,9 @@ body {
 .gpii-prefsEditor-panelContainer {
     width: 43em;
 }
+#gpiic-pcp .gpii-prefsEditor-panelContainer {
+    width: 35.5em;
+}
 
 .gpii-prefsEditor-frameIcon {
     font-family: C4Aicons;
@@ -79,10 +82,13 @@ body {
     border: 1px solid #ced7d9;
     padding: 10px;
 }
+#gpiic-pcp .gpii-prefsEditor-preferences {
+    padding: 2px 0;
+}
 
 .gpii-prefsEditor-PCP-preferences {
     overflow-y: auto;
-    width: 40.9em;
+    width: 40.9em; /*CS: apparently can't be changed to auto or a lower em value*/
 }
 
 .gpii-prefsEditor-save, .gpii-prefsEditor-gotoPcp {
@@ -125,8 +131,8 @@ body {
     display: inline-block;
     padding: 1em;
     white-space: normal;
-    width: 55%;
-    font-style:italic;
+    width: 75%; /* CS: was 55% */
+    /*font-style:italic;*//*CS: italic is less readable*/
     vertical-align: middle;
     font-size: 1.2em;
     background-color: #CED7D9;
@@ -202,9 +208,11 @@ body {
 
 .gpii-prefsEditor-notificationConfirmButton {
     display: inline-block;
-    font-style: italic;
+    /*font-style: italic;*//*CS: italic is less readable and unusual for buttons*/
     font-weight: bold;
     cursor: pointer;
+    color: black;
+    background-color: #CED7D9;
 }
 
 .gpii-prefsEditor-notificationMessageTOKEN {
@@ -254,6 +262,9 @@ body {
 .gpii-prefsEditor-userStatusBar {
     display: inline-block;
     width: 99%;
+}
+#gpiic-pcp .gpii-prefsEditor-userStatusBar {
+    width: 100%; /*97%??*/
 }
 
 .gpii-pcp-statusMessage {

--- a/src/shared/schemas/js/pcpSchema.js
+++ b/src/shared/schemas/js/pcpSchema.js
@@ -49,6 +49,50 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
         }
     });
 
+
+    fluid.defaults("gpii.pcp.auxiliarySchema.windows", {
+        auxiliarySchema: {
+            // The preference-specific information:
+            "groups": {
+                "addContrast": {
+                    "container": ".gpii-prefsEditor-contrastPanel",
+                    "template": "%prefix/addContrastTemplate.html",
+                    "message": "%prefix/message.json",
+                    "type": "gpii.adjuster.addContrast",
+                    "panels": {
+                        "always": ["contrastEnabled"],
+                        "gpii.primarySchema.contrastEnabled": ["contrastTheme"]
+                    }
+                }
+            },
+            "contrastEnabled": {
+                "type": "gpii.primarySchema.contrastEnabled",
+                "panel": {
+                    "type": "gpii.adjuster.contrastEnabled",
+                    "container": ".gpiic-contrastEnabled",
+                    "template": "%prefix/onOffSwitchTemplate.html",
+                    "message": "%prefix/contrast.json"
+                }
+            },
+            "contrastTheme": {
+                "type": "gpii.primarySchema.contrast.theme",
+                "classes": {
+                    "black-white": "fl-theme-prefsEditor-bw gpii-prefsEditor-theme-bw fl-theme-bw",
+                    "white-black": "fl-theme-prefsEditor-wb gpii-prefsEditor-theme-wb fl-theme-wb",
+                    "black-yellow": "fl-theme-prefsEditor-by gpii-prefsEditor-theme-by fl-theme-by",
+                    "yellow-black": "fl-theme-prefsEditor-yb gpii-prefsEditor-theme-yb fl-theme-yb"
+                },
+                "panel": {
+                    "type": "gpii.adjuster.contrastThemeNoPreview",
+                    "container": ".gpiic-contrastTheme",
+                    "template": "%prefix/contrastThemeNoPreviewTemplate.html",
+                    "message": "%prefix/contrast.json",
+                    "classnameMap": {"theme": "@contrastTheme.classes"}
+                }
+            }
+        }
+    });
+
 // TODO KASPER
 // <<<<<<< HEAD
 //     fluid.defaults("gpii.pcp.auxiliarySchema.windows", {

--- a/src/shared/schemas/js/primarySchema.js
+++ b/src/shared/schemas/js/primarySchema.js
@@ -145,8 +145,8 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
             "enum": ["en", "el", "de", "es"]
         },
 
-        
-        //  Data for application specific terms
+
+        //  Data for application-specific terms
 
 
         // Windows


### PR DESCRIPTION
The high contrast theme adjuster displays again, now in a smaller size
than in the PMT.
The `#gpiic-pcp` IDs in the CSS are intentional; they make sure that the PMT remains unaffected by the CSS changes for the PCP.
