### PR TITLE
NOJIRA: ON/OFF indicator rendering still unsolved.

### DIFF
--- a/src/shared/adjusters/html/onOffSwitchTemplate.html
+++ b/src/shared/adjusters/html/onOffSwitchTemplate.html
@@ -5,7 +5,7 @@
     <div id="gpii-onOffSwitch-onOff" class="fl-prefsEditor-onoff">
         <input type="checkbox" id="onOffSwitchInput" class="gpiic-onOffSwitch-input"/>
         <label for="onOffSwitchInput">
-            <span class="gpiic-prefsEditor-onOffSwitch fl-prefsEditor-switch" data-checkboxStateOn="" data-checkboxStateOff="" tabindex="0">
+            <span class="gpiic-prefsEditor-onOffSwitch fl-prefsEditor-switch" data-checkboxStateOn="ON" data-checkboxStateOff="OFF" tabindex="0">
                 <span class="fl-prefsEditor-switch-inner"></span>
             </span>
         </label>

--- a/src/shared/adjusters/js/onOffSwitch.js
+++ b/src/shared/adjusters/js/onOffSwitch.js
@@ -48,15 +48,15 @@ https://github.com/GPII/prefsEditors/blob/master/%20LICENSE.txt
                 "this": "{that}.dom.onOffSwitch",
                 "method": "attr",
                 // TODO fix this lookup so the attribute gets a value
-                //"args": ["data-checkboxStateOn", "{that}.msgLookup.onText"] 
-                "args": ["data-checkboxStateOn", "ON"]
+                "args": ["data-checkboxStateOn", "{that}.msgLookup.onText"] 
+                //"args": ["data-checkboxStateOn", "ON"]
             },
             "onDomBind.setOffText": {
                 "this": "{that}.dom.onOffSwitch",
                 "method": "attr",
                 // TODO fix this lookup so the attribute gets a value
-                //"args": ["data-checkboxStateOff", "{that}.msgLookup.offText"] 
-                "args": ["data-checkboxStateOff", "OFF"]
+                "args": ["data-checkboxStateOff", "{that}.msgLookup.offText"] 
+                //"args": ["data-checkboxStateOff", "OFF"]
             }
         },
         invokers: {


### PR DESCRIPTION
The attributes `data-checkboxStateOn` and `data-checkboxStateOff` on the contrast on/off switch somehow do not get a value. Still not clear how to fix this. This temporary hack is only OK for English.

The other part of this PR are some styles to make sure that the contrast icon is at normal size (unlike PMT). The ID `#gpiic-pcp` makes sure that the PMT is not affected. 
